### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,68 @@
+name: 🐛 Roku bug report
+description: Report a bug/issue affecting the Hydravion Roku Channel
+labels: ["bug"]
+body:
+    - type: checkboxes
+      attributes:
+        label: Checklist before submitting a bug report
+        options:
+        - label: This bug/issue is affecting the Hydravion Roku Channel
+          descriptiom: For other platforms see [here](https://github.com/bmlzootown/Hydravion/issues/new/choose)
+          required: true
+        - label: I've searched for existing [issues](https://github.com/bmlzootown/Hydravion/issues?q=is:issue) and found no duplicates
+          required: true
+        - label: I understand that this project is run by volunteer contributors therefore completion of this issue cannot be guaranteed
+          required: true
+
+    - type: input
+      id: devicemodel
+      attributes:
+          label: Device Model
+          description: Settings --> System --> About, Model
+          placeholder: e.g. 4660X - Roku Ultra
+      validations:
+          required: true
+
+    - type: input
+      id: osversion
+      attributes:
+          label: OS Version
+          description: Settings --> System --> About, Software version
+          placeholder: e.g. 11.5.0 build 4312-46
+      validations:
+          required: true
+
+    - type: input
+      id: channelversion
+      attributes:
+          label: Channel Version
+          description: Highlight channel, access options (*) menu, see "version X.X build X"
+          placeholder: e.g. 2.1 build 3
+      validations:
+          required: true
+
+    - type: input
+      id: subscriptions
+      attributes:
+          label: Whom you are subscribed to?
+          description: Sometimes issues are subscription specific
+          placeholder: e.g. LTT, Garbage Time, Bitwit, Lvl1
+      validations:
+          required: true
+
+    - type: markdown
+      attributes:
+        value: Please detail one bug per GitHub issue
+
+    - type: textarea
+      id: details
+      attributes:
+        label: Error/Issue Details
+        description: |
+          What is the issue you're experiencing? How can we re-produce it?
+          Please be as specific as possible
+          - Is the error/issue occurring on a specific channel only?
+          - Does it only affect specific videos?
+          - Does the issue still occur when trying to play the video at a different resolution? (Access the options menu when looking at the video description, "Select Resolution")
+          - Can you provide any screenshots?
+        placeholder: Detailed explanation of the issue along with replication steps

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: true
+contact_links:
+  - name: AndroidTV issues, feedback & feature requests
+    url: https://github.com/bmlzootown/Hydravion-AndroidTV/issues
+    about: Please use the Hydravion-AndroidTV issues page
+
+  - name: Apple TV/tvOS issues, feedback & feature requests
+    url: https://github.com/Jman012/Wasserflug-tvOS/issues
+    about: Please use the Wasserflug-tvOS issues page
+
+  - name: Questions
+    url: https://discord.gg/4xKDGz5M5B
+    about: Join the Discord server for help with regular/general questions

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,30 @@
+name: 🚀 Roku feature request
+description: Feature request for the Hydravion Roku Channel
+labels: ["enhancement"]
+body:
+    - type: checkboxes
+      attributes:
+        label: Checklist before submitting a feature request
+        options:
+        - label: This feature request is for the Hydravion Roku Channel
+          descriptiom: For other platforms see [here](https://github.com/bmlzootown/Hydravion/issues/new/choose)
+          required: true
+        - label: I've searched for existing [requests](https://github.com/bmlzootown/Hydravion/issues?q=is:issue) and found no duplicates
+          required: true
+        - label: I understand that this project is run by volunteer contributors therefore completion of this request cannot be guaranteed
+          required: true
+
+    - type: markdown
+      attributes:
+        value: Please detail one feature request per GitHub issue
+
+    - type: textarea
+      id: details
+      attributes:
+        label: New Feature Details
+        description: |
+          What would be the expected behavior of the new feature?
+          Are there any links/screenshots that can be provided relating to this?
+        placeholder: Detailed explanation of the new feature
+      validations:
+        required: true


### PR DESCRIPTION
@bmlzootown this is a great project and I've been using this Roku channel for some time without any issues.

I noticed you occasionally need to ask for extra info/copy issues to the other projects (Hydravion-AndroidTV & Wasserflug-tvOS) where they don't relate to the Roku channel.

Hopefully these issue templates will help reduce this for you and possibly allow you to close #20.

I can create a PR for the Hydravion-AndroidTV project with the same if you like and see if @Jman012 would like this also to point people back this way for Roku/Android TV issues/requests.